### PR TITLE
docs: clarify Month 8 OSCAL aggregator role

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ This script supports FedRAMP 20x compliance-as-code by aggregating multi-control
 
 CJIS v6.0 (audit standard from April 1, 2026) requires continuous monitoring and weekly audit-record review for systems handling Criminal Justice Information (CJI). The compliance report is the *review surface* for that workflow — a single document an authorizing official, system owner, or CJIS coordinator reviews to confirm controls are satisfied and findings are being remediated on schedule. Combined with `cloudtrail-audit` (AU-6 review tooling), `evidence-logger` (timestamped evidence), and S3 Object Lock archival (1-year retention), the report becomes the visible top of a fully audit-defensible CJIS continuous-monitoring stack.
 
+## Roadmap
+
+This tool aggregates findings produced by the per-resource audit tools (`s3-audit`, `sg-audit`, `iam-audit`). In **Month 7** those tools consolidate into the **Unified Evidence Collector** (Project 4); in **Month 8** this tool extends to consume the collector's output and emit OSCAL Assessment Results JSON alongside the HTML report, feeding [`oscal-evidence-pipeline`](https://github.com/0xBahalaNa/oscal-evidence-pipeline) for FedRAMP 20x continuous-monitoring pipelines. The HTML report remains the primary review surface for human reviewers; the OSCAL JSON becomes the machine-readable contract.
+
 ## Future Enhancements
 
 - Add CloudTrail findings to report (AU-6 events)
@@ -129,7 +133,7 @@ CJIS v6.0 (audit standard from April 1, 2026) requires continuous monitoring and
 - Add charts / graphs with Chart.js (KSI visualization)
 - Compare with previous reports (trend analysis)
 - Add remediation recommendations linked to control IDs
-- Emit OSCAL Assessment Results JSON alongside HTML (FedRAMP 20x)
+- Emit OSCAL Assessment Results JSON alongside HTML (FedRAMP 20x; see *Roadmap*)
 
 ## Framework Reference
 


### PR DESCRIPTION
## Summary

- Add a **Roadmap** section explaining the Month 7 (consume Unified Evidence Collector output) + Month 8 (emit OSCAL Assessment Results JSON alongside HTML) plan
- Clarifies that the HTML report stays the primary human review surface; OSCAL JSON becomes the machine-readable contract for \`oscal-evidence-pipeline\`
- Tags the existing "Emit OSCAL JSON" *Future Enhancement* line with a back-reference to *Roadmap* so the relationship is explicit

## Test Plan

- [x] Roadmap renders between *CJIS v6.0 Relevance* and *Future Enhancements*
- [x] oscal-evidence-pipeline cross-link resolves