### PR TITLE
docs: correct CJIS v6.0 audit timeline to phased rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This script supports FedRAMP 20x compliance-as-code by aggregating multi-control
 
 ## CJIS v6.0 Relevance
 
-CJIS v6.0 (audit standard from April 1, 2026) requires continuous monitoring and weekly audit-record review for systems handling Criminal Justice Information (CJI). The compliance report is the *review surface* for that workflow — a single document an authorizing official, system owner, or CJIS coordinator reviews to confirm controls are satisfied and findings are being remediated on schedule. Combined with `cloudtrail-audit` (AU-6 review tooling), `evidence-logger` (timestamped evidence), and S3 Object Lock archival (1-year retention), the report becomes the visible top of a fully audit-defensible CJIS continuous-monitoring stack.
+CJIS v6.0 (published Dec 27, 2024; default audit baseline from April 1, 2026; Priority 2-4 fully enforceable Oct 1, 2027) requires continuous monitoring and weekly audit-record review for systems handling Criminal Justice Information (CJI). The compliance report is the *review surface* for that workflow — a single document an authorizing official, system owner, or CJIS coordinator reviews to confirm controls are satisfied and findings are being remediated on schedule. Combined with `cloudtrail-audit` (AU-6 review tooling), `evidence-logger` (timestamped evidence), and S3 Object Lock archival (1-year retention), the report becomes the visible top of a fully audit-defensible CJIS continuous-monitoring stack.
 
 ## Roadmap
 


### PR DESCRIPTION
## Summary
- Corrects the CJIS v6.0 audit-timeline language from a single-cutover framing ("v6.0 becomes/became the audit standard on April 1, 2026") to the verified phased rollout.
- Phased framing: v5.9.5 was the scored audit standard through March 31, 2026; v6.0 is the default audit baseline from April 1, 2026; modernized Priority 2–4 controls fully enforceable Oct 1, 2027 (timing varies by state CSA).
- Surrounding control content (AU-6 / SC-28 / delta mappings) preserved verbatim.

## Why
The April 1, 2026 date is the default go-forward audit baseline, not a one-day enforcement cutover. The corrected framing matches the FBI CJIS v6.0 phased rollout.

## Test Plan
- [x] Dates cross-checked against the canonical reconciled CJIS v6.0 timeline
- [x] Grep sweep — zero residual single-cutover phrasing in tracked files

Factual documentation correction — no issue.